### PR TITLE
Avoid a crash-on-exit due to streams closing.

### DIFF
--- a/src/ofxKinect2.cpp
+++ b/src/ofxKinect2.cpp
@@ -473,6 +473,8 @@ void ColorStream::setPixels(Frame frame)
 	int num_pixels = w * h;
 
 	const unsigned char * src = (const unsigned char*)frame.data;
+	if(!src)
+		return;
 	unsigned char *dst = pix.getBackBuffer().getPixels();
 
 	pix.getBackBuffer().setFromPixels(src, w, h, OF_IMAGE_COLOR_ALPHA);
@@ -720,6 +722,8 @@ void DepthStream::setPixels(Frame frame)
 	Stream::setPixels(frame);
 	
 	const unsigned short *pixels = (const unsigned short*)frame.data;
+	if(!pixels)
+		return;
 	int w = frame.width;
 	int h = frame.height;
 	
@@ -907,6 +911,8 @@ void IrStream::setPixels(Frame frame)
 	Stream::setPixels(frame);
 
 	const unsigned short *pixels = (const unsigned short*)frame.data;
+	if(!pixels)
+		return;
 	int w = frame.width;
 	int h = frame.height;
 	


### PR DESCRIPTION
If the stream is closed while it is still running, the stream's thread
might crash because the frame data becomes null. Since the nulling of the
frame data is normal, we add a check for it to avoid the crash.