### PR TITLE
Add a public getter for Stream::kinect2_timestamp.

### DIFF
--- a/src/ofxKinect2.h
+++ b/src/ofxKinect2.h
@@ -132,6 +132,7 @@ public:
 	float getDiagonalFieldOfView();
 
 	inline bool isFrameNew() const { return is_frame_new; }
+	inline uint64_t getFrameTimestamp() const { return kinect2_timestamp; }
 
 	void draw(float x = 0, float y = 0);
 	virtual void draw(float x, float y, float w, float h);


### PR DESCRIPTION
The kinect2_timestamp variable can be used by non-main threads to detect
new frames. Exposing this variable therefore facilitates multithreaded
processing of Kinect stream data, which is very useful when doing e.g.
heavy CV work off the main thread.